### PR TITLE
Use String new instead of quotes #2

### DIFF
--- a/lib/hansi/string_renderer.rb
+++ b/lib/hansi/string_renderer.rb
@@ -35,7 +35,7 @@ module Hansi
       scanner = StringScanner.new(input)
       insert  = true
       stack   = []
-      output  = ""
+      output  = String.new
 
       until scanner.eos?
         if scanner.scan(@simple)


### PR DESCRIPTION
### Motivation
Hansi is not compatible with --enable=frozen-string-literal. Running with such option raises Runtime error:  

```
FrozenError:
       can't modify frozen String: ""
```

### Issue

https://github.com/rkh/hansi/issues/2

### Changes

* Change double quotes (`""`) to `String.new` 

### Addition notes

Command I have used to run the specs (in project root directory): 
```
RUBYOPT=--enable=frozen-string-literal bundle exec rspec
```
